### PR TITLE
Fixes: entrypoint default, mount flags, mount to string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ fn get_default_devices() -> Vec<String> {
 }
 
 fn get_default_entrypoint() -> bool {
-    return false;
+    return true;
 }
 
 fn get_default_env() -> HashMap<String, String> {

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -166,6 +166,14 @@ impl SarusMount {
 
         return Ok(em);
     }
+
+    pub fn to_volume_string(&self) -> String {
+        if self.flags.is_empty() {
+            format!("{}:{}", self.source, self.target)
+        } else {
+            format!("{}:{}:{}", self.source, self.target, self.flags)
+        }
+    }
 }
 
 pub fn sarus_mounts_from_strings(input: Vec<String>) -> SarusResult<SarusMounts> {


### PR DESCRIPTION
- execute container entrypoint by default
- expect mount flags to be provided as valid flags for Podman mounts; do not translate them to fstab flags, which are not valid for Podman
- add SarusMount method to represent the mount as a String with valid syntax for Podman's `--volume` option