### PR TITLE
Introduce minimum sanitization for the Bash-evaluated strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ serde = { version = "1.0.225", features = ["derive"] }
 serde_json = "1.0.145"
 shellexpand = "3.1.1"
 toml = "0.9.5"
+regex = "1.12.2"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use std::collections::HashMap;
 use std::process::Command;
 
@@ -17,14 +18,20 @@ fn expand_vars_string_with_env(
     input: String,
     env: &HashMap<String, String>,
 ) -> SarusResult<String> {
-    /*
-     * Running bash here, as a unprivileged user, I suppose.
-     * Probably there is a security need for vetting:
-     * * running user (?)
-     * * input (?)
-     * * env (?)
-     */
+    // Ban any strings that will attempt to execute something upon evaluation.
+    let re_banned = Regex::new(r#"([^\\]|^)(\$\(|`|;|")"#).unwrap();
+    if re_banned.is_match(&input) {
+        return Err(SarusError {
+            code: 18,
+            file_path: None,
+            msg: String::from(format!("cannot expand string {input}, invalid string")),
+        });
+    }
+
+    // Evaluate 'input' in a restricted shell.
+    // This will block any redirection attempts, among other things.
     let output = Command::new("bash")
+        .arg("-r")
         .arg("-c")
         .arg(format!("echo -n \"{}\"", &input))
         .env_clear()
@@ -95,4 +102,51 @@ pub fn expand_vars_vec(
         newv.push(expand_vars_string(s, env)?);
     }
     return Ok(newv);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn check_expand_vars_string(
+        input: &str,
+        expected: &str
+    ) -> bool {
+        let mut env = HashMap::new();
+        env.insert("XXX".to_string(), "111".to_string());
+        match expand_vars_string_with_env(input.to_string(), &env) {
+            Ok(s) => {
+                println!("{}", s);
+                return s == expected;
+            }
+            Err(_) => return false,
+        }
+    }
+
+    #[test]
+    fn expand_vars_normal_strs() {
+        assert!(check_expand_vars_string(r#"xxx-$XXX-xxx"#, r#"xxx-111-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-${XXX}-xxx"#, r#"xxx-111-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-${XXX:1}-xxx"#, r#"xxx-11-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-${YYY:-222}-xxx"#, r#"xxx-222-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-${YYY}-xxx"#, r#"xxx--xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-\$(XXX)-xxx"#, r#"xxx-$(XXX)-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-$\(XXX)-xxx"#, r#"xxx-$\(XXX)-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx-\`XXX\`-xxx"#, r#"xxx-`XXX`-xxx"#));
+        assert!(check_expand_vars_string(r#"xxx--xxx\;"#, r#"xxx--xxx\;"#));
+        assert!(check_expand_vars_string(r#"\"xxx--xxx\""#, r#""xxx--xxx""#));
+    }
+
+    #[test]
+    fn expand_vars_banned_strs() {
+        assert!(!check_expand_vars_string(r#"xxx-$(XXX)-xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"xxx-`XXX`-xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"xxx-"-xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"xxx--xxx;"#, ""));
+        assert!(!check_expand_vars_string(r#"$(XXX)xxx--xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"`XXX`xxx--xxx"#, ""));
+        assert!(!check_expand_vars_string(r#""xxx--xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"; xxx--xxx"#, ""));
+        assert!(!check_expand_vars_string(r#"" >/tmp/file"#, ""));
+    }
 }


### PR DESCRIPTION
This MR introduces a simple regex-based input sanitization against Bash-evaluated strings.

- The regex rule filters out the strings that execute something upon evaluation (i.e., `$(...)` and `` `...` ``).
- The regex rule also filters out any attempt to close a quotation block and start a new command (i.e., `... " ...` and `... ; ...`).
- The evaluation shell is _restricted_ to block any file redirections.

This MR ultimately aims only to enable variable expansion and the related Bash keywords (e.g., `~`). Future sanitization may be included to improve this further. It passed the unit tests (included in this MR).